### PR TITLE
Correções de login e cadastro de filmes

### DIFF
--- a/BackEnd/src/main/java/com/RenanMartins/apirestfulv1/controller/AutenticacaoController.java
+++ b/BackEnd/src/main/java/com/RenanMartins/apirestfulv1/controller/AutenticacaoController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.*;
 
 import com.RenanMartins.apirestfulv1.model.Cliente;
 import com.RenanMartins.apirestfulv1.service.AutenticacaoService;
-import com.RenanMartins.apirestfulv1.util.TokenResponse;
 
 @CrossOrigin("http://localhost:5173")
 @RestController
@@ -16,13 +15,12 @@ public class AutenticacaoController {
     private AutenticacaoService autenticacaoService;
 
     @PostMapping("login")  // http://localhost:8080/autenticacao/login
-    public TokenResponse login(@RequestBody Cliente usuario) {
+    public Cliente login(@RequestBody Cliente usuario) {
         System.out.println(usuario.getConta() + " " + usuario.getSenha());
         Cliente usuarioLogado = autenticacaoService.login(usuario);
         if (usuarioLogado != null) {
-            return new TokenResponse(usuarioLogado.getId());
-        } else {
-            return new TokenResponse(0);
+            return usuarioLogado;
         }
+        return new Cliente();
     }
 }

--- a/BackEnd/src/main/java/com/RenanMartins/apirestfulv1/util/TokenResponse.java
+++ b/BackEnd/src/main/java/com/RenanMartins/apirestfulv1/util/TokenResponse.java
@@ -1,5 +1,0 @@
-package com.RenanMartins.apirestfulv1.util;
-
-public record TokenResponse(long token) {
-}
-

--- a/FrontEnd/src/components/FilmeForm.tsx
+++ b/FrontEnd/src/components/FilmeForm.tsx
@@ -7,6 +7,7 @@ import databaseEdit from "../assets/skin/database_edit.png";
 import databaseCancel from "../assets/skin/multiply.png";
 import useAlterarFilme from "../hooks/useAlterarFilme";
 import useCadastrarFilme from "../hooks/useCadastrarFilme";
+import useRecuperarGeneros from "../hooks/useRecuperarGeneros";
 import { useFilmeStore } from "../store/FilmeStore";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,6 +18,9 @@ const schema = z.object({
   diretor: z.string().nonempty("O diretor deve ser informado.").min(3),
   anoLancamento: z.coerce.number().min(1900),
   imagem: z.string().nonempty("A imagem deve ser informada."),
+  generoId: z.coerce
+    .number({ invalid_type_error: "O gênero deve ser selecionado." })
+    .gt(0, "O gênero deve ser selecionado."),
 });
 
 type FilmeForm = z.infer<typeof schema>;
@@ -29,16 +33,29 @@ const FilmeForm = () => {
   const { mutate: cadastrarFilme, error: errorCadastrarFilme } = useCadastrarFilme();
   const { mutate: alterarFilme, error: errorAlterarFilme } = useAlterarFilme();
 
-  const { register, handleSubmit, setValue, reset, formState: { errors } } = useForm<FilmeForm>({
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { errors },
+  } = useForm<FilmeForm>({
     defaultValues: {
       titulo: "",
       sinopse: "",
       diretor: "",
       anoLancamento: undefined,
       imagem: "",
+      generoId: 0,
     },
     resolver: zodResolver(schema),
   });
+
+  const {
+    data: generos,
+    isPending: carregandoGeneros,
+    error: errorGeneros,
+  } = useRecuperarGeneros();
 
   const setValoresIniciais = () => {
     if (filmeSelecionado?.id) {
@@ -47,6 +64,7 @@ const FilmeForm = () => {
       setValue("diretor", filmeSelecionado.diretor);
       setValue("anoLancamento", filmeSelecionado.anoLancamento);
       setValue("imagem", filmeSelecionado.imagem);
+      setValue("generoId", filmeSelecionado.genero.id);
     } else {
       reset();
     }
@@ -56,7 +74,7 @@ const FilmeForm = () => {
     setValoresIniciais();
   }, [filmeSelecionado]);
 
-  const submit = ({ titulo, sinopse, diretor, anoLancamento, imagem }: FilmeForm) => {
+  const submit = ({ titulo, sinopse, diretor, anoLancamento, imagem, generoId }: FilmeForm) => {
     const filme = {
       titulo,
       slug: slugify(titulo, { lower: true, strict: true }),
@@ -64,6 +82,7 @@ const FilmeForm = () => {
       diretor,
       anoLancamento,
       imagem,
+      genero: { id: generoId },
     };
 
     if (filmeSelecionado?.id) {
@@ -112,6 +131,26 @@ const FilmeForm = () => {
         <label htmlFor="imagem">Imagem</label>
         <input {...register("imagem")} type="text" id="imagem" className={`form-control ${errors.imagem ? "is-invalid" : ""}`} />
         <div className="invalid-feedback">{errors.imagem?.message}</div>
+      </div>
+      <div className="mb-2">
+        <label htmlFor="generoId">Gênero</label>
+        {carregandoGeneros ? (
+          <p>Carregando gêneros...</p>
+        ) : (
+          <select
+            {...register("generoId", { valueAsNumber: true })}
+            id="generoId"
+            className={`form-select ${errors.generoId ? "is-invalid" : ""}`}
+          >
+            <option value="0">Selecione</option>
+            {generos?.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.nome}
+              </option>
+            ))}
+          </select>
+        )}
+        <div className="invalid-feedback">{errors.generoId?.message}</div>
       </div>
       <div className="mt-3">
         <button type="submit" className="btn btn-primary me-2">

--- a/FrontEnd/src/components/LoginForm.tsx
+++ b/FrontEnd/src/components/LoginForm.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import { useLocation, useNavigate } from "react-router-dom";
 import loginIcon from "../assets/skin/login.png";
 import { useEfetuarLogin } from "../hooks/useEfetuarLogin";
-import { TokenResponse } from "../interfaces/TokenResponse";
 import { Cliente } from "../interfaces/Cliente";
 import { useClienteStore } from "../store/ClienteStore";
 

--- a/FrontEnd/src/hooks/useRecuperarGeneros.ts
+++ b/FrontEnd/src/hooks/useRecuperarGeneros.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "./useAPI";
+import { Genero } from "../interfaces/Genero";
+import ResultadoPaginado from "../interfaces/ResultadoPaginado";
+
+const useRecuperarGeneros = () => {
+  return useQuery({
+    queryKey: ["generos"],
+    queryFn: async () => {
+      const { data } = await api.get<ResultadoPaginado<Genero>>("/generos", {
+        params: { pagina: 0, tamanho: 100, nome: "" },
+      });
+      return data.itens;
+    },
+  });
+};
+
+export default useRecuperarGeneros;

--- a/FrontEnd/src/interfaces/TokenResponse.ts
+++ b/FrontEnd/src/interfaces/TokenResponse.ts
@@ -1,4 +1,0 @@
-interface TokenResponse {
-    token: number;
-}
-export default TokenResponse;

--- a/FrontEnd/src/routes/router.tsx
+++ b/FrontEnd/src/routes/router.tsx
@@ -26,7 +26,6 @@ const router = createBrowserRouter([
         ],
       },
       { path: "filmes", element: <FilmesComPaginacaoPage /> },
-      { path: "carrinho", element: <CarrinhoPage /> },
       { path: "cadastrar-filme", element: <CadastrarFilmePage /> },
       { path: "filmes/:id", element: <FilmePage /> },
       { path: "registro", element: <RegistroPage /> },
@@ -35,9 +34,10 @@ const router = createBrowserRouter([
   },
   {
     path: "/",
-    element: <PrivateRoutes />, 
-    errorElement: <ErrorPage />, 
+    element: <PrivateRoutes />,
+    errorElement: <ErrorPage />,
     children: [
+      { path: "carrinho", element: <CarrinhoPage /> },
       { path: "favoritos", element: <FavoritosPage /> },
     ],
   },


### PR DESCRIPTION
## Summary
- devolve `Cliente` ao efetuar login
- proteger rota do carrinho com `PrivateRoutes`
- adicionar seleção de gênero no `FilmeForm`
- hook para buscar gêneros no front-end
- remover código legado de token

## Testing
- `npm run build` *(fails: npm not installed)*
- `./mvnw -q test` *(fails: missing maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687a0e9c3f58832ea88f768d9e718acc